### PR TITLE
v1.3.0 - CASMCMS-7676 - support for recipe templates.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-[Unreleased]
+## [Unreleased]
 
-[1.0.0] - (no date)
+## [1.3.0] - 2022-06-29
+### Changed
+- Updated ims-python-helper to require v2.9.0 or above.
+
+## [1.0.0] - (no date)

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -27,6 +27,7 @@ branches:
   main:
     regex: ^master$|^main$
     mode: ContinuousDelivery
+    tag: rc
   develop:
     regex: ^develop$
     increment: Minor           ## The NEXT release will be 1.2.0 if the latest production release is 1.1.x

--- a/constraints.txt
+++ b/constraints.txt
@@ -4,7 +4,7 @@ certifi==2019.11.28
 chardet==3.0.4
 docutils==0.14
 idna==2.8
-ims-python-helper>=2.7.29
+ims-python-helper>=2.9.0
 jmespath==0.9.4
 oauthlib==2.1.0
 python-dateutil==2.8.1


### PR DESCRIPTION
## Summary and Scope

Pull in the new version of ims-python-helper to get the new recipe template arguments in the helper functions.

Changes to ims-python-helper:
https://github.com/Cray-HPE/ims-python-helper/pull/11

## Issues and Related PRs
* Resolves [CASMCMS-7676](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7676)

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
