### PR TITLE
CASMINST-5443: Authenticate to CSM's artifactory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Authenticate to CSM's artifactory
 
 ## [1.4.0] - 2022-08-02
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,9 +32,8 @@ COPY zypper-refresh-patch-clean.sh /
 RUN /zypper-refresh-patch-clean.sh && rm /zypper-refresh-patch-clean.sh
 
 RUN pip3 install --upgrade pip
-RUN pip3 install \
-       --no-cache-dir \
-       -r requirements.txt
+RUN --mount=type=secret,id=netrc,target=/root/.netrc \
+    pip3 install --no-cache-dir -r requirements.txt
 
 VOLUME /mnt/image
 VOLUME /mnt/recipe

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -40,6 +40,7 @@ pipeline {
         NAME = "cray-ims-kiwi-ng-opensuse-x86_64-builder"
         DESCRIPTION = "Cray image management service openSUSE-based (x86-64) kiwi-ng image build environment"
         IS_STABLE = getBuildIsStable()
+	DOCKER_BUILDKIT = "1"
     }
 
     stages {

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,10 @@
 NAME ?= ims-kiwi-ng-opensuse-x86_64-builder
 DOCKER_VERSION ?= $(shell head -1 .docker_version)
 
+ifneq ($(wildcard ${HOME}/.netrc),)
+        DOCKER_ARGS ?= --secret id=netrc,src=${HOME}/.netrc
+endif
+
 all : runbuildprep lint image 
 
 runbuildprep:


### PR DESCRIPTION
## Summary and Scope

Authenticate to CSM's artifactory when using pip to access CSM's csm-python-modules.


## Issues and Related PRs


* Resolves CASMINST-5443

## Testing


### Tested on:

  * Build environment

### Test description:

It builds successfully.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

