### PR TITLE
CASMCMS-8366 - add arm64 image support.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- CASMCMS-8366 - add support for arm64 to the docker image.
+
 ## [1.4.2] - 2022-12-20
 ### Added
 - Add Artifactory authentication to Jenkinsfile
-
-## [Unreleased]
 
 ## [1.4.1] - 2022-012-02
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2018, 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2018, 2021-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -22,7 +22,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 # Cray Image Management Service image build environment Dockerfile
-FROM arti.hpc.amslabs.hpecorp.net/baseos-docker-master-local/opensuse-leap:15.2 as base
+FROM artifactory.algol60.net/csm-docker/stable/docker.io/opensuse/leap:15.4 as base
 
 COPY requirements.txt constraints.txt /
 RUN zypper in -y python3-pip python3-kiwi xz jing

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -2,7 +2,7 @@
  *
  *  MIT License
  *
- *  (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+ *  (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a
  *  copy of this software and associated documentation files (the "Software"),
@@ -40,7 +40,7 @@ pipeline {
         NAME = "cray-ims-kiwi-ng-opensuse-x86_64-builder"
         DESCRIPTION = "Cray image management service openSUSE-based (x86-64) kiwi-ng image build environment"
         IS_STABLE = getBuildIsStable()
-	DOCKER_BUILDKIT = "1"
+        DOCKER_BUILDKIT = "1"
     }
 
     stages {
@@ -90,7 +90,7 @@ pipeline {
             }
 
             steps {
-                publishCsmDockerImage(image: env.NAME, tag: env.DOCKER_VERSION, isStable: env.IS_STABLE)
+                publishCsmDockerImage(image: env.NAME, tag: env.DOCKER_VERSION, isStable: env.IS_STABLE, multiArch: true)
             }
         }
     }

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -25,6 +25,7 @@
 # cms-meta-tools repo to ./cms_meta_tools
 
 NAME ?= ims-kiwi-ng-opensuse-x86_64-builder
+
 DOCKER_VERSION ?= $(shell head -1 .docker_version)
 
 ifneq ($(wildcard ${HOME}/.netrc),)
@@ -40,4 +41,7 @@ lint:
 		./cms_meta_tools/scripts/runLint.sh
 
 image:
-		docker build --pull ${DOCKER_ARGS} --tag '${NAME}:${DOCKER_VERSION}' .
+		docker buildx create --use
+		docker buildx build --platform=linux/amd64,linux/arm64 --pull ${DOCKER_ARGS} .
+		docker buildx build --platform=linux/amd64 --load --tag '${NAME}:${DOCKER_VERSION}' .
+		docker buildx build --platform=linux/arm64 --load --tag '${NAME}:${DOCKER_VERSION}-arm64' .


### PR DESCRIPTION
## Summary and Scope

Create version of the image with both linux/arm64 and linux/amd64 versions supported.

## Issues and Related PRs
* Resolves [CASMCMS-8366](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8366)

## Testing
### Tested on:
  * `Surtur`

### Test description:

I examined the produced manifest file for the image and it lists both linux/arm64 and linux/amd64 based images. I then installed the image on Surtur and ran customization jobs to insure the image works in existing x86 image jobs. The testing for the arm64 side will have to wait until we have the qemu emulator set up.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? N
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Low risk - just adding support for another architecture for this image. 

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
