### PR TITLE
CASMINST-6450 - pin ims-python-helper for csm-1.3.4 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.3] - 2023-06-06
+### Changed
+- CASMINST-6450 - Pin versions for csm-1.3.4 release.
+
 ## [1.4.2] - 2022-12-20
 ### Added
 - Add Artifactory authentication to Jenkinsfile

--- a/constraints.txt
+++ b/constraints.txt
@@ -4,7 +4,7 @@ certifi==2019.11.28
 chardet==3.0.4
 docutils==0.14
 idna==2.8
-ims-python-helper>=2.9.0
+ims-python-helper==2.10.2
 jmespath==0.9.4
 oauthlib==2.1.0
 python-dateutil==2.8.1


### PR DESCRIPTION
## Summary and Scope

The csm-1.3.4 release picked up some new (incompatible) changes from the latest ims-python-helper. This pins the release of ims-python-helper that should be used so each compile will not update that version. 

## Issues and Related PRs
* Resolves [CASMINST-6450](https://jira-pro.it.hpe.com:8443/browse/CASMINST-6450)

## Testing
### Tested on:
  * `Fanta`

### Test description:

I verified the 1.3.4 upgrade was not working correctly, then updated the version of ims-utils being used to this one, and re-tested and all works as it should.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? N
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This is a low risk change, as it just pins the version of ims-python-helper to what was being used when the release originally went out.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
