### PR TITLE
Casmcms 8590

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.5.3] - 2023-06-18
 ### Changed
+- CASM-8590: Utilize artifactory image for Dockerfile 
+
+## [1.5.3] - 2023-06-18
+### Changed
 - CASM-4232: Require at least version 2.14.0 of `ims-python-helper` in order to get associated logging enhancements.
 
 ## [1.5.2] - 2023-05-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.5.3] - 2023-06-18
+## [1.5.4] - 2023-06-15
 ### Changed
 - CASM-8590: Utilize artifactory image for Dockerfile 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@
 # Cray Image Management Service image build environment Dockerfile
 # NOTE - currently the algol version does not have arm64 platform - update this when it does
 #FROM artifactory.algol60.net/csm-docker/stable/docker.io/opensuse/leap:15.4 as base
-FROM opensuse/leap:15.4 as base
+FROM arti.dev.cray.com/baseos-docker-master-local/opensuse-leap:15.4 as base
 
 COPY requirements.txt constraints.txt /
 RUN zypper in -y python3-pip python3-kiwi xz jing curl podman kmod make wget 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 # Cray Image Management Service image build environment Dockerfile
-FROM artifactory.algol60.net/csm-docker/unstable/docker.io/opensuse/leap:15.4 as base
+FROM artifactory.algol60.net/csm-docker/stable/docker.io/opensuse/leap:15.4 as base
 
 COPY requirements.txt constraints.txt /
 RUN zypper in -y python3-pip python3-kiwi xz jing curl podman kmod make wget 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 # Cray Image Management Service image build environment Dockerfile
-# NOTE - currently the algol version does not have arm64 platform - update this when it does
-#FROM artifactory.algol60.net/csm-docker/stable/docker.io/opensuse/leap:15.4 as base
-FROM arti.dev.cray.com/baseos-docker-master-local/opensuse-leap:15.4 as base
+FROM artifactory.algol60.net/csm-docker/stable/docker.io/opensuse/leap:15.4 as base
 
 COPY requirements.txt constraints.txt /
 RUN zypper in -y python3-pip python3-kiwi xz jing curl podman kmod make wget 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 # Cray Image Management Service image build environment Dockerfile
-FROM artifactory.algol60.net/csm-docker/stable/docker.io/opensuse/leap:15.4 as base
+FROM artifactory.algol60.net/csm-docker/unstable/docker.io/opensuse/leap:15.4 as base
 
 COPY requirements.txt constraints.txt /
 RUN zypper in -y python3-pip python3-kiwi xz jing curl podman kmod make wget 


### PR DESCRIPTION
## Summary and Scope
 Needed to make algol image a multiplatform image to enable arm64 suse builder.
[CASMCMS-8590](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8590)

## Testing


### Tested on:
Tested on mug.

### Test description:
Run ims builds on new builder.

## Risks and Mitigations
None


## Pull Request Checklist

- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable

