### PR TITLE
Hotfix/casmcms 8708

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- CASMCMS-8708 Rework multi-image build
 
 ## [1.5.4] - 2023-06-15
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.5.5] - 2023-07-11
 - CASMCMS-8708 Rework multi-image build
 
 ## [1.5.4] - 2023-06-15

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -80,19 +80,21 @@ pipeline {
 
             steps {
                 echo "Docker args are ${env.DOCKER_ARGS}"
-                sh "make image"
+                withCredentials([usernamePassword(credentialsId: 'artifactory-algol60-publish', passwordVariable: 'ARTIFACTORY_PASSWORD', usernameVariable: 'ARTIFACTORY_USERNAME')]) {
+                    sh "echo \$ARTIFACTORY_PASSWORD | docker login artifactory.algol60.net --username \$ARTIFACTORY_USERNAME --password-stdin"
+                    sh "make image"
+                }
             }
         }
 
         stage("Publish") {
             environment {
-                BUILD_ARGS = " "
                 DOCKER_VERSION = sh(returnStdout: true, script: "head -1 .docker_version").trim()
             }
 
             steps {
                 echo "Docker version is ${env.DOCKER_VERSION}"
-                publishCsmDockerImage(image: env.NAME, tag: env.DOCKER_VERSION, isStable: env.IS_STABLE, multiArch: true)
+                publishCsmDockerImage(image: env.NAME, tag: env.DOCKER_VERSION, isStable: env.IS_STABLE, push: false)
             }
         }
     }

--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,12 @@
 # cms-meta-tools repo to ./cms_meta_tools
 
 NAME ?= ims-kiwi-ng-opensuse-x86_64-builder
-
 DOCKER_VERSION ?= $(shell head -1 .docker_version)
+ifeq ($(IS_STABLE),true)
+	DOCKER_NAME ?= artifactory.algol60.net/csm-docker/stable/$(NAME)
+else
+	DOCKER_NAME ?= artifactory.algol60.net/csm-docker/unstable/$(NAME)
+endif
 
 ifneq ($(wildcard ${HOME}/.netrc),)
         DOCKER_ARGS ?= --secret id=netrc,src=${HOME}/.netrc
@@ -42,5 +46,8 @@ lint:
 
 image:
 		docker buildx create --use
-		docker buildx build --platform=linux/amd64,linux/arm64 --pull ${DOCKER_ARGS} .
-		docker buildx build --platform=linux/amd64 --load --tag '${NAME}:${DOCKER_VERSION}' .
+		docker buildx build --push --platform=linux/amd64,linux/arm64 ${DOCKER_ARGS} --tag '${DOCKER_NAME}:${DOCKER_VERSION}' .
+
+image_local:
+		docker buildx create --use
+		docker buildx build --load ${DOCKER_ARGS} --tag '${DOCKER_NAME}:${DOCKER_VERSION}' .


### PR DESCRIPTION
## Summary and Scope
From https://github.com/Cray-HPE/ims-kiwi-ng-opensuse-x86_64-builder/pull/54:

Currently, `docker build buildx` is called 3 times during build, with different set of parameters (2 times within `Makefile` and one more time in `publishCsmDockerImage` method of csm-shared-libraries). This change (which also depends on https://github.com/Cray-HPE/csm-shared-library/pull/52) is to unify `docker buildx build` invocation.

Since images for multiple platforms can not be loaded into local docker daemon, separate single-platform target was introduced in `Makefile` to make local image. I.e.
* run `make image` to build both platforms (`amd64` and `arm64`) and push them to `artifactory.algol60.net`. No images will be loaded into local docker daemon. Authentication to `artifactory.algol60.net` must be established with `docker login` prior to that.
* run `make image_local`to build single platform image and load it into local docker. Image for your laptop platform will be built (`amd64` for Intel based Mac's, `arm64` for newer Mac chips). No push to `artifactory.algol60.net` happens, preliminary auth is not needed.

Note: filing it as DRAFT, since branch `feature/deprecate-multiarch` of `csm-shared-libraries` is supposed to go away, once https://github.com/Cray-HPE/csm-shared-library/pull/52 gets merged.

## Issues and Related PRs

* Resolves [CASMCMS-8708](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8708)

## Testing
### Tested on:

  * Local development environment
  * Jenkins: https://jenkins.algol60.net/blue/organizations/jenkins/Cray-HPE%252Fims-kiwi-ng-opensuse-x86_64-builder/detail/feature%252FCASMCMS-8708/3/

### Test description:
* Tested local build with `make image_local`
* Tested non-local multi-platform builds: https://jenkins.algol60.net/blue/organizations/jenkins/Cray-HPE%252Fims-kiwi-ng-opensuse-x86_64-builder/detail/feature%252FCASMCMS-8708/3/
