### PR TITLE
CASMCMS-8722: Use update_external_versions to get latest patch version of ims-python-helper Python module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Dependencies
+- CASMCMS-8722: Use `update_external_versions` to get latest patch version of `ims-python-helper` Python module.
 
 ## [1.5.6] - 2023-07-11
 ### Changed

--- a/constraints.txt
+++ b/constraints.txt
@@ -4,7 +4,7 @@ certifi==2019.11.28
 chardet==3.0.4
 docutils==0.14
 idna==2.8
-ims-python-helper>=2.14.0
+ims-python-helper==0.0.0-imspython
 jmespath==0.9.4
 oauthlib==2.1.0
 python-dateutil==2.8.1

--- a/update_external_versions.conf
+++ b/update_external_versions.conf
@@ -1,0 +1,4 @@
+image: ims-python-helper
+    source: python
+    major: 2
+    minor: 14

--- a/update_versions.conf
+++ b/update_versions.conf
@@ -1,0 +1,20 @@
+#tag: version tag string to be replaced (optional -- if unspecified @VERSION@ is assumed)
+#sourcefile: file to read actual version from (optional -- if unspecified, .version is assumed)
+#targetfile: file in which to have version tags replaced
+#
+#Multiples of these lines are allowed. A given line is in effect until another line overrides it.
+#Example:
+#tag: @TAG1@
+#sourcefile: path/to/version1.txt
+#targetfile: my/file.py
+#targetfile: other/file.yaml
+#
+#tag: @TAG2@
+#targetfile: a/b/c.txt
+#
+#sourcefile: v2.txt
+#targetfile: 1/2/3.txt
+
+sourcefile: ims-python-helper.version
+tag: 0.0.0-imspython
+targetfile: constraints.txt


### PR DESCRIPTION
## Summary and Scope

Now that `update_external_versions` handles Python modules, this update this repo to use it in order to grab the latest patch version of the `ims-python-helper` Python module.

(This was prompted by my noticing some cases in other repos where we are using outdated versions of our Python modules)