### PR TITLE
CASMCMS-8795 - fixes for remote build.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- CASMCMS-8795 - Updated for remote builds.
 
 ## [1.6.0] - 2023-09-15
 ### Changed

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -66,6 +66,9 @@ function run_emulation_build() {
 
     # run the arm64 kiwi build inside this new pod
     podman --storage-driver=vfs pull --platform linux/arm64 docker://registry.local/$IMS_ARM_BUILDER
+
+    # NOTE: if we can get --cpu-rt-runtime=950000 to work in the below command, it will 
+    #  allow the process to use up much more of the CPU. Currently get 'cpu feature not supported' error.
     podman --storage-driver=vfs run  --privileged --platform linux/arm64 --entrypoint "/scripts/armentry.sh" -e BUILD_ARCH=$BUILD_ARCH -v /signing-keys:/signing-keys -v /mnt/image/recipe/:/mnt/image/recipe -v /mnt/image:/mnt/image -v /etc/cray/ca/:/etc/cray/ca/ -v /mnt/ca-rpm/:/mnt/ca-rpm  docker://registry.local/$IMS_ARM_BUILDER
 }
 
@@ -77,7 +80,7 @@ function run_remote_build() {
     echo BUILD_ARCH=${BUILD_ARCH} >> /env.sh
     echo IMS_JOB_ID=${IMS_JOB_ID} >> /env.sh
     echo IMAGE_ROOT_PARENT=${IMAGE_ROOT_PARENT} >> /env.sh
-    echo RECIPE_ROOT_PARENT=/data/recipe >> env.sh
+    echo RECIPE_ROOT_PARENT=/data/recipe >> /env.sh
 
     # Modify the dockerfile to use the correct base image
     (echo "cat <<EOF" ; cat Dockerfile.remote ; echo EOF ) | sh > Dockerfile

--- a/scripts/remote_entrypoint.sh
+++ b/scripts/remote_entrypoint.sh
@@ -78,6 +78,7 @@ echo "Calling kiwi-ng build..."
 kiwi-ng \
     $DEBUG_FLAGS \
     --logfile=$PARAMETER_FILE_KIWI_LOGFILE \
+    --target-arch=$BUILD_ARCH \
     --type tbz system build \
     --description $RECIPE_ROOT_PARENT \
     --target $IMAGE_ROOT_PARENT \


### PR DESCRIPTION
## Summary and Scope

Slight changes found when working on running jobs on a remote build node.

## Issues and Related PRs
* Resolves [CASMCMS-8795](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8795)

## Testing
### Tested on:
  * `Mug`

### Test description:

Installed on Mug via helm, and tested remote builds manually.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Low risk as these are small changes.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

