### PR TITLE
CASMCMS-9024 - include DST signing keys in kiwi-ng build arguments.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- CASMCMS-9024 - include DST signing in kiwi-ng build arguments.
+
 ## [1.10.0] - 2025-06-25
 ### Dependencies
 - CASMCMS-8022:  update python modules

--- a/Dockerfile.remote
+++ b/Dockerfile.remote
@@ -40,4 +40,7 @@ ENV RECIPE_ROOT_PARENT=/data/recipe
 # Copy in the recipe
 COPY /mnt/image/recipe/. /data/recipe
 
+# Copy DST signing keys
+COPY /etc/cray/signing-keys/. /signing-keys
+
 ENTRYPOINT ["/scripts/remote_build_entrypoint.sh"]


### PR DESCRIPTION
## Summary and Scope

The DST signing keys are included in a K8S secret. This change takes those keys and adds them to the kiwi-ng call which allows updated keys without needing to rebuild the base image.

## Issues and Related PRs
* Resolves [CASMCMS-9024](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9024)

## Testing
### Tested on:
  * `Surtur`

### Test description:

I upgraded the ims service via loftsman and ran recipe builds both local and remote, with and without the K8S secret's signing keys present. I then rolled back to the previous version of IMS and verified it works correctly.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This is a medium risk change just due to the number of changes needed, but it has been well tested.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

