### PR TITLE
CASMCMS-9473 - add DST signing keys to emulation build.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.11.1] - 2025-06-30
+### Changed
+- CASMCMS-9473 - include DST signing in kiwi-ng build arguments in emulation builds.
+
 ## [1.11.0] - 2025-06-25
 ### Changed
 - CASMCMS-9024 - include DST signing in kiwi-ng build arguments.

--- a/scripts/armentry.sh
+++ b/scripts/armentry.sh
@@ -49,6 +49,31 @@ if [[ ! $RC ]]; then
 	exit 1
 fi
 
+# Copy all the DST signing keys into the signing-keys directory
+if [ -d /etc/cray/signing-keys ]; then
+    for file in /etc/cray/signing-keys/*; do
+        if [[ -f $file ]]; then
+            cp $file /signing-keys/
+        fi
+    done
+fi
+
+# set up the signing keys args
+SIGNING_KEYS_ARGS=""
+for file in /signing-keys/*; do
+    if [[ -f $file ]]; then
+        new_len=$((${#SIGNING_KEYS_ARGS} + ${#file} + 14)) # 14 = length of "--signing-key "
+        if [ $new_len -lt 4096 ]; then
+            # If the length of the args is less than 4096, add the signing key
+            # to the args list. If it is longer, skip it.
+            # This is a workaround for the kiwi-ng command line length limit.
+            SIGNING_KEYS_ARGS+="--signing-key $file "
+        else
+            echo "WARNING: Skipping signing key $file due to command line length limit."
+        fi
+    fi
+done
+
 # Call kiwi to build the image recipe. Note that the command line --add-bootstrap-package
 # causes kiwi to install the cray-ca-cert rpm into the image root.
 kiwi-ng \
@@ -59,9 +84,7 @@ kiwi-ng \
     --description $RECIPE_ROOT_PARENT \
     --target $IMAGE_ROOT_PARENT \
     --add-bootstrap-package file:///mnt/ca-rpm/cray_ca_cert-1.0.1-1.noarch.rpm \
-    --signing-key /signing-keys/HPE-SHASTA-RPM-PROD.asc \
-    --signing-key /signing-keys/HPE-SHASTA-RPM-PROD-FIPS.public \
-    --signing-key /signing-keys/SUSE-gpg-pubkey-39db7c82-5f68629b.asc
+    $SIGNING_KEYS_ARGS
 rc=$?
 
 if [ "$rc" -ne "0" ]; then

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -71,9 +71,16 @@ function run_emulation_build() {
     # run the arm64 kiwi build inside this new pod
     podman --storage-driver=vfs pull --platform linux/arm64 docker://registry.local/$IMS_ARM_BUILDER
 
+    # The dockerfile expects a dir at `/etc/cray/signing-keys` which should be a mounted secret
+    # If the dir does not exist, create it
+    if [ ! -d /etc/cray/signing-keys ]; then
+        echo "Creating /etc/cray/signing-keys directory"
+        mkdir -p /etc/cray/signing-keys
+    fi
+
     # NOTE: if we can get --cpu-rt-runtime=950000 to work in the below command, it will 
     #  allow the process to use up much more of the CPU. Currently get 'cpu feature not supported' error.
-    podman --storage-driver=vfs run  --privileged --platform linux/arm64 --entrypoint "/scripts/armentry.sh" -e BUILD_ARCH=$BUILD_ARCH -v /signing-keys:/signing-keys -v /mnt/image/recipe/:/mnt/image/recipe -v /mnt/image:/mnt/image -v /etc/cray/ca/:/etc/cray/ca/ -v /mnt/ca-rpm/:/mnt/ca-rpm  docker://registry.local/$IMS_ARM_BUILDER
+    podman --storage-driver=vfs run  --privileged --platform linux/arm64 --entrypoint "/scripts/armentry.sh" -e BUILD_ARCH=$BUILD_ARCH -v /signing-keys:/signing-keys -v /mnt/image/recipe/:/mnt/image/recipe -v /mnt/image:/mnt/image -v /etc/cray/signing-keys/:/etc/cray/signing-keys -v /etc/cray/ca/:/etc/cray/ca/ -v /mnt/ca-rpm/:/mnt/ca-rpm docker://registry.local/$IMS_ARM_BUILDER
 }
 
 function run_remote_build() {


### PR DESCRIPTION
## Summary and Scope

At the time the main work was done to use the DST signing keys during the kiwi-ng build, the path of running a local emulation build was missed. This copies over the signing keys to the emulation env and modifies the kiwi-ng call to dynamically build the list of signing key arguments.

## Issues and Related PRs
* Resolves [CASMCMS-9473](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9473)

## Testing
### Tested on:
  * `Surtur`

### Test description:

Installed the new version and ran an aarch64 emulation build. Verified the additional signing keys were added to the kiwi-ng call.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Low risk - just adding the same code to the emulation run.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

