### PR TITLE
CASMCMS-8904 - remote build optimizations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## Changed
+- CASMCMS-8904 - optimize remote node builds.
 
 ## [1.11.1] - 2025-06-30
 ### Changed

--- a/Dockerfile.remote
+++ b/Dockerfile.remote
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -27,7 +27,7 @@ FROM registry.local/$IMS_ARM_BUILDER as base
 
 # Copy the cert rpm & signing keys
 COPY /mnt/ca-rpm/cray_ca_cert-1.0.1-1.noarch.rpm /data/ca-rpm/cray_ca_cert-1.0.1-1.noarch.rpm
-COPY /etc/cray/ca/certificate_authority.crt /etc/cray/ca/certificate_authority.crt
+COPY /etc/cray/ca/* /etc/cray/ca/
 COPY /etc/admin-client-auth /etc/admin-client-auth
 
 # set env variables
@@ -36,6 +36,9 @@ ENV BUILD_ARCH=$BUILD_ARCH
 ENV IMS_JOB_ID=$IMS_JOB_ID
 ENV IMAGE_ROOT_PARENT=$IMAGE_ROOT_PARENT
 ENV RECIPE_ROOT_PARENT=/data/recipe
+ENV KERNEL_FILENAME=$KERNEL_FILENAME
+ENV INITRD_FILENAME=$INITRD_FILENAME
+ENV KERNEL_PARAMETERS_FILENAME=$KERNEL_PARAMETERS_FILENAME
 
 # Copy in the recipe
 COPY /mnt/image/recipe/. /data/recipe

--- a/scripts/armentry.sh
+++ b/scripts/armentry.sh
@@ -44,16 +44,16 @@ else
 fi
 update-ca-certificates
 RC=$?
-if [[ ! $RC ]]; then
+if [[ $RC -ne 0 ]]; then
 	echo "update-ca-certificates exited with return code: $RC "
 	exit 1
 fi
 
 # Copy all the DST signing keys into the signing-keys directory
-if [ -d /etc/cray/signing-keys ]; then
+if [[ -d /etc/cray/signing-keys ]]; then
     for file in /etc/cray/signing-keys/*; do
         if [[ -f $file ]]; then
-            cp $file /signing-keys/
+            cp "$file" /signing-keys/
         fi
     done
 fi
@@ -63,7 +63,7 @@ SIGNING_KEYS_ARGS=""
 for file in /signing-keys/*; do
     if [[ -f $file ]]; then
         new_len=$((${#SIGNING_KEYS_ARGS} + ${#file} + 14)) # 14 = length of "--signing-key "
-        if [ $new_len -lt 4096 ]; then
+        if [[ $new_len -lt 4096 ]]; then
             # If the length of the args is less than 4096, add the signing key
             # to the args list. If it is longer, skip it.
             # This is a workaround for the kiwi-ng command line length limit.
@@ -79,19 +79,19 @@ done
 kiwi-ng \
     $DEBUG_FLAGS \
     --target-arch=$BUILD_ARCH \
-    --logfile=$PARAMETER_FILE_KIWI_LOGFILE \
+    --logfile="$PARAMETER_FILE_KIWI_LOGFILE" \
     --type tbz system build \
-    --description $RECIPE_ROOT_PARENT \
-    --target $IMAGE_ROOT_PARENT \
+    --description "$RECIPE_ROOT_PARENT" \
+    --target "$IMAGE_ROOT_PARENT" \
     --add-bootstrap-package file:///mnt/ca-rpm/cray_ca_cert-1.0.1-1.noarch.rpm \
     $SIGNING_KEYS_ARGS
-rc=$?
+RC=$?
 
-if [ "$rc" -ne "0" ]; then
+if [[ $RC -ne 0 ]]; then
   echo "ERROR: Kiwi reported a build error."
   echo "Outputting kiwi log file."
-  cat $PARAMETER_FILE_KIWI_LOGFILE
-  touch $PARAMETER_FILE_BUILD_FAILED
+  cat "$PARAMETER_FILE_KIWI_LOGFILE"
+  touch "$PARAMETER_FILE_BUILD_FAILED"
 fi
 
 # Always return 0


### PR DESCRIPTION
## Summary and Scope

Make changes to the remote build process to minimize extra work copying and squashing/unsquashing the image. This pushes more work to happen on the remote node so that once the image file is transferred back to the job pod it no longer needs further modification.

This requires changes in:
ims
ims-utils
ims-sshd
ims-kiwi-ng-opensuse-x86_64-builder

## Issues and Related PRs
* Resolves [CASMCMS-8904](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8904)

## Testing
### Tested on:
  * `Mug`, and `Odin`

### Test description:

Installed the changes on the system and built complete images (from uss recipe, including shs, cos, gpu, sma, etc products) both remotely and locally and verified they booted and configured correctly. This was done with both x86 and aarch64 images. 

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This is a medium risk change, but has been pretty thoroughly tested.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

